### PR TITLE
Show author image from github profile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -30,3 +30,4 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
 
 gem "webrick", "~> 1.7"
+gem "jekyll-avatar"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-avatar (0.7.0)
+      jekyll (>= 3.0, < 5.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.1.0)
@@ -71,6 +73,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.2.0)
+  jekyll-avatar
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -42,6 +42,7 @@ assets: "/silver-broccoli-urban-fiesta/assets"
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-avatar
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -32,7 +32,9 @@ layout: default
 
         <div class="post-meta">
           {%- if post.author -%}
-          <div class="author-avatar"></div>
+          <div class="author-avatar">
+            {%- avatar {{ post.author }} size=56 -%}
+          </div>
           <div class="author-name">{{ post.author }}</div>
           {%- endif -%}
           <div class="post-date">{{ post.date | date: date_format }}</div>

--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -238,10 +238,7 @@ $banner-height: calc(360px * 0.75);
         justify-content: flex-end;
         align-items: center;
 
-        .author-avatar {
-          // TODO: properly implement getting avatar image
-          background-image: url(https://avatars.githubusercontent.com/u/583231?s=56);
-          background-size: contain;
+        .author-avatar .avatar {
           width: 56px;
           height: 56px;
           border-radius: 50%;


### PR DESCRIPTION
- get author image by post.author info
- TODO: review a policy for author name
  - is it okay to show as like 'hnc-gildong'?

![image](https://user-images.githubusercontent.com/82790390/119808317-f5481c80-bf1e-11eb-83c5-61a634e96cd4.png)
