### PR TITLE
Fix H1 font size problem

### DIFF
--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -372,3 +372,9 @@ $max-tablet-width: 1023px;  // $min-desktop-width - 1
     }
   }
 }
+
+// early application of https://github.com/jekyll/minima/pull/273
+// TODO: remove after an official update of minima theme
+.post-content h1 {
+  @extend .post-title;
+}


### PR DESCRIPTION
- by applying https://github.com/jekyll/minima/pull/273,
  before an official update of minima theme.

(before)
![image](https://user-images.githubusercontent.com/82790390/121996454-a0901700-cde3-11eb-8a24-bda1c7c84aa1.png)
-> (after)
![image](https://user-images.githubusercontent.com/82790390/121996504-af76c980-cde3-11eb-80c6-adc5a822ac72.png)
