### PR TITLE
Fix title in tablet mode in Safari

### DIFF
--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -151,6 +151,7 @@ $bg4-y: calc(100% - 224px);
       letter-spacing: -0.31px;
       color: #ffffff;
       overflow: hidden;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
- the title string was cropped unexpectedly.
- problem:
<img width="355" alt="Screen Shot 2021-07-05 at 10 41 43" src="https://user-images.githubusercontent.com/82790390/124406944-ae4f1180-dd7d-11eb-8a96-7c6ad51289a2.png">
