### PR TITLE
Fix styling of many tags

### DIFF
--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -337,11 +337,12 @@ $bg4-y: calc(100% - 224px);
   list-style-type: none;
   display: flex;
   justify-content: flex-start;
+  flex-wrap: wrap;
   margin: 0;
 
   .tag-item {
     height: 30px;
-    margin-right: 6px;
+    margin: 0 6px 6px 0;
     padding: 0 16px;
     border-radius: 16px;
     background-color: #f0f0f0;
@@ -351,6 +352,7 @@ $bg4-y: calc(100% - 224px);
     font-family: NotoSansCJKkr, sans-serif;
     font-size: 13px;
     color: #333333;
+    white-space: nowrap;
   }
 }
 

--- a/docs/_sass/post-with-comments.scss
+++ b/docs/_sass/post-with-comments.scss
@@ -96,13 +96,4 @@
   .wrapper {
     margin: 0 16px;
   }
-
-  .tag-list {
-    display: inline-block;
-
-    .tag-item {
-      margin: 4px;
-      width: fit-content;
-    }
-  }
 }


### PR DESCRIPTION
example screenshots)

- post list page (on desktop)
<img width="962" alt="Screen Shot 2021-07-16 at 11 49 56" src="https://user-images.githubusercontent.com/82790390/125884508-e1459374-4d5a-4eb4-9909-35e6343eea65.png">

- post content page (on mobile)
<img width="400" alt="Screen Shot 2021-07-16 at 11 50 15" src="https://user-images.githubusercontent.com/82790390/125884517-a05b9535-9dc1-4775-ba7d-a941576b7f64.png">
