### PR TITLE
Fix some elements sizes

### DIFF
--- a/docs/_sass/custom-phone.scss
+++ b/docs/_sass/custom-phone.scss
@@ -66,6 +66,7 @@
 
           .post-link {
             font-size: 18px;
+            height: 18px;
           }
 
           .post-excerpt {
@@ -77,12 +78,12 @@
         .post-meta {
           .author-avatar {
             margin: 0 8px 0 0;
-  
+
             > .avatar {
               width: 24px;
               height: 24px;
             }
-          }  
+          }
         }
       }
     }

--- a/docs/_sass/post-with-comments.scss
+++ b/docs/_sass/post-with-comments.scss
@@ -80,9 +80,9 @@
   margin: 56px 0 120px;
 
   .button-to-list {
-    width: 144px;
+    width: fit-content;
     height: 48px;
-    padding: 17px 32px;
+    padding: 0 32px;
     border-radius: 4px;
     border: solid 1px #bdbdbd;
     background-color: white;


### PR DESCRIPTION
- fix back-to-the-list button width error: on Windows Chrome
- fix some small dots below a long post title: on iOS Safari

<img width="296" alt="Screen Shot 2021-07-16 at 17 43 06" src="https://user-images.githubusercontent.com/82790390/125919687-85521b4d-c694-41f7-a201-f1b6690df353.png">

