### PR TITLE
Fix post title text formatting

### DIFF
--- a/docs/_sass/custom-phone.scss
+++ b/docs/_sass/custom-phone.scss
@@ -107,7 +107,8 @@
 
           .post-link {
             font-size: 18px;
-            height: 18px;
+            height: 20px;
+            line-height: 1.1em;   // needed to remove clutters of next line in zoom-in
           }
 
           .post-excerpt {

--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -338,6 +338,7 @@ $bg4-y: calc(100% - 224px);
           font-family: NotoSansCJKkr, sans-serif;
           font-weight: 500;
           font-size: 24px;
+          height: 26px;
           letter-spacing: -0.4px;
           color: #111111;
         }


### PR DESCRIPTION
- problem: the descender part (under the baseline) of characters were
  clipped unexectedly.

- problem example) see the 'g' characters
<img width="634" alt="Screen Shot 2021-08-17 at 10 57 49 AM" src="https://user-images.githubusercontent.com/82790390/129652249-d2a48a77-13c2-4920-aabd-d2e41cde705e.png">
