### PR TITLE
Fix title overlapping with nav bar

### DIFF
--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -191,6 +191,7 @@ $bg4-y: calc(100% - 224px);
   .site-title {
     width: 408px;
     height: 60px;
+    z-index: -1;
   }
 
   .site-desc {


### PR DESCRIPTION
- fix title to be shown as clipped by the nav bar
- problem screenshot:
<img width="531" alt="Screen Shot 2021-09-02 at 6 57 03 PM" src="https://user-images.githubusercontent.com/82790390/131824288-625524c3-0227-4061-a858-9022197e50b0.png">
