### PR TITLE
Fix mp4 playback in iPhone Safari

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -5,7 +5,7 @@
 {% if isHome %}{% assign siteHeaderClass = 'site-header-big' %}{% endif %}
 <header class="site-header {{ siteHeaderClass }}" role="banner">
   {% if isHome %}
-  <video class="bg-video" muted autoPlay loop>
+  <video class="bg-video" muted autoplay loop playsinline>
     <source src="{{ site.assets }}/site-img/background.mp4" type="video/mp4" />
   </video>
   {% endif %}


### PR DESCRIPTION
- by adding 'playsinline' attr in 'video' tag
- (by the way, the mp4 video is not played back in phone-size window
  by UI spec.)