### PR TITLE
Fix too small subtitle text

### DIFF
--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -213,6 +213,7 @@ $bg4-y: calc(100% - 224px);
       }
     }
     &-anim {
+      width: 700px;
       height: 30px;
     }
   }


### PR DESCRIPTION
- on Safari in iPadOS 15
- problem screenshot:
<img width="800" alt="too-small-subtitle-in-ipad-safari" src="https://user-images.githubusercontent.com/82790390/134478315-26b8db34-9c66-4986-85f2-f2f9c7d05826.png">

