### PR TITLE
Remove clutters of second line of post titles

### DIFF
--- a/docs/_sass/custom-phone.scss
+++ b/docs/_sass/custom-phone.scss
@@ -112,7 +112,7 @@
           .post-link {
             font-size: 18px;
             height: 20px;
-            line-height: 1.1em;   // needed to remove clutters of next line in zoom-in
+            line-height: 1.2em;   // needed to remove clutters of next line in zoom-in
           }
 
           .post-excerpt {


### PR DESCRIPTION
- problem: some dots from second line might be shown unexpectedly.
  - checked on mobile Safari in iOS 15
  - problem screenshot:
  - ![image](https://user-images.githubusercontent.com/82790390/134478671-26c15124-67d6-4e41-b52f-02dadb722cd2.png)
