### PR TITLE
Fix unexpected attaching of Utterances widget

### DIFF
--- a/docs/_layouts/post-with-comments.html
+++ b/docs/_layouts/post-with-comments.html
@@ -42,7 +42,7 @@ layout: default
 <div class="comment-widget">
   <script src="https://utteranc.es/client.js"
           repo="hancom-io/didactic-octo-palm-tree"
-          issue-term="title"
+          issue-term="pathname"
           label="comment"
           theme="github-light"
           crossorigin="anonymous"


### PR DESCRIPTION
- problem:
  - Utterances comment widget was attached wrongfully to a new post.
  - the comments of the widget were for another blog post.
  - (the comments of '가볍게 읽는 닷넷 프레임워크(.NET Framework)의 진화 이야기'
     were also appeared for '가볍게 읽는 닷넷(.NET)의 진화 이야기')

- cause:
  - Utterances seems to have a bug of identifying a post by 'title'.

- resolution:
  - change Utterances setting: use 'pathname' instead of 'title'

- TODO:
  - change titles of the previous 'issues' of blog comments repo:
    - before: blog post title
    - after: blog post pathname