### PR TITLE
Prevent unexpected selection on logo image etc.

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -31,7 +31,7 @@
       </div>
     </div>
 
-    <div class="family-site-box">
+    <div class="family-site-box no-select">
       <select
         onchange="window.location.href=this.value; this.value=null;"
         >

--- a/docs/_includes/nav-menu.html
+++ b/docs/_includes/nav-menu.html
@@ -1,5 +1,5 @@
 <div class="nav-menu-inner-box">
-  <div class="items">
+  <div class="items no-select">
     <img class="bi-white" src="{{ site.assets }}/site-img/bi-white.svg">
     <div class="v-sep"></div>
     <a class="menu-item" href="{{ '/' | relative_url }}">블로그</a>

--- a/docs/_includes/pagination.html
+++ b/docs/_includes/pagination.html
@@ -19,7 +19,7 @@
     - 21-23 (if 23 is the last page)
 {% endcomment %}
 
-<div class="pagination">
+<div class="pagination no-select">
   {% if page.url != '/' %}
   <a href="{{ '/' | relative_url }}">
     <div class="page-unit">{{ arrow_first }}</div>

--- a/docs/_layouts/post-with-comments.html
+++ b/docs/_layouts/post-with-comments.html
@@ -51,7 +51,7 @@ layout: default
 </div>
 
 <div class="button-box">
-  <button class="button-to-list"
+  <button class="button-to-list no-select"
     onclick='window.history.back()'
     >
     이전 목록으로

--- a/docs/_sass/common.scss
+++ b/docs/_sass/common.scss
@@ -15,6 +15,12 @@ $highlight-blue: #2e5fd8;
   visibility: hidden;
 }
 
+.no-select,
+.no-select * {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 .one-line {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/docs/_sass/custom.scss
+++ b/docs/_sass/custom.scss
@@ -180,6 +180,7 @@ $bg4-y: calc(100% - 224px);
             &::placeholder {
               color: white;
               opacity: 0.6;
+              user-select: none;
             }
           }
         }


### PR DESCRIPTION
- prevent selection on the items below:
  - logo image (and nav bar items)
  - placeholder text in search bar
  - pagination control
  - family site text
  - 'back-to-list' button text
- tested in:
  - macOS Chrome/Firefox/Safari
  - Win10 Chrome/Firefox/Edge