### PR TITLE
Fix pagination: wrong link for page 1

### DIFF
--- a/docs/_includes/pagination.html
+++ b/docs/_includes/pagination.html
@@ -40,7 +40,7 @@
     {% if page == current_page %}
     <div class="page-unit current">{{ page }}</div>
     {% elsif page == 1 %}
-    <a href="{{ paginator.previous_page_path | relative_url }}">
+    <a href="{{ '/' | relative_url }}">
       <div class="page-unit">{{ page }}</div>
     </a>
     {% else %}


### PR DESCRIPTION
- problem: the link for page 1 was wrongfully set as 'page 2', when
  the current page was page 3.

- solution: set always the link for page 1 as '/'.